### PR TITLE
Adapt to ISO C23

### DIFF
--- a/rwhoisd/common/attributes.c
+++ b/rwhoisd/common/attributes.c
@@ -557,7 +557,7 @@ add_attribute(attr, class, attr_ref_list)
   if( !dl_list_last(attr_list))
   {
     /* this is the first entry, so default the list */
-    dl_list_default(attr_list, FALSE, destroy_attr_data);
+    dl_list_default(attr_list, FALSE, (int(*)(void*))destroy_attr_data);
   }
   else
   {
@@ -608,7 +608,7 @@ add_global_attribute(attr, class, attr_ref_list, global_id)
     if (! dl_list_last(attr_ref_list))
     {
       *global_id = 0;
-      dl_list_default(attr_ref_list, FALSE, destroy_attr_ref_data);
+      dl_list_default(attr_ref_list, FALSE, (int(*)(void *))destroy_attr_ref_data);
     }
     else
     {

--- a/rwhoisd/common/auth_area.c
+++ b/rwhoisd/common/auth_area.c
@@ -1166,7 +1166,7 @@ add_auth_area(aa)
   {
     auth_area_list = xcalloc(1, sizeof(*auth_area_list));
 
-    dl_list_default(auth_area_list, TRUE, destroy_auth_area_data);
+    dl_list_default(auth_area_list, TRUE, (int(*)(void *))destroy_auth_area_data);
   }
 
   /* check the aa for existance, syntax, etc .. first */
@@ -1634,7 +1634,7 @@ add_server(srv_list_ptr, val)
 
   if (dl_list_empty(list))
   {
-    dl_list_default(list, TRUE, destroy_server_data);
+    dl_list_default(list, TRUE, (int(*)(void*))destroy_server_data);
   }
 
   dl_list_append(list, server);
@@ -2260,7 +2260,7 @@ create_auth_area(aa)
   {
     auth_area_list = xcalloc(1, sizeof(*auth_area_list));
 
-    dl_list_default(auth_area_list, TRUE, destroy_auth_area_data);
+    dl_list_default(auth_area_list, TRUE, (int(*)(void *))destroy_auth_area_data);
   }
 
   dl_list_append(auth_area_list, newaa);

--- a/rwhoisd/common/dir_security.c
+++ b/rwhoisd/common/dir_security.c
@@ -86,7 +86,7 @@ create_dir_security(wrap_list, wrap_type)
 {
   *wrap_list = xcalloc(1, sizeof(**wrap_list));
 
-  if (!dl_list_default(*wrap_list, TRUE, destroy_dir_security_data))
+  if (!dl_list_default(*wrap_list, TRUE, (int(*)(void *))destroy_dir_security_data))
   {
     log(L_LOG_ERR, CONFIG,
         "Error in creating %s directive security list", wrap_type);

--- a/rwhoisd/common/directive_conf.c
+++ b/rwhoisd/common/directive_conf.c
@@ -374,7 +374,7 @@ initialize_directive_list()
     dl_list_destroy(&directive_list);
   }
   
-  dl_list_default(&directive_list, FALSE, destroy_directive_data);
+  dl_list_default(&directive_list, FALSE, (int(*)(void *))destroy_directive_data);
 }
 
 

--- a/rwhoisd/common/dl_list.c
+++ b/rwhoisd/common/dl_list.c
@@ -33,7 +33,7 @@ int
 dl_list_default(list, destroy_head_flag, destroy_data)
   dl_list_type  *list;
   int           destroy_head_flag;
-  int           (*destroy_data)();
+  int           (*destroy_data)(void *);
 {
   if (list) {
     list->head              = NULL;

--- a/rwhoisd/common/dl_list.h
+++ b/rwhoisd/common/dl_list.h
@@ -41,7 +41,7 @@ typedef struct _dl_list_type
    function pointer to the data free()ing routine. */
 int dl_list_default PROTO((dl_list_type *list,
                            int destroy_head_flag,
-                           int (*destroy_data)()));
+                           int (*destroy_data)(void *data)));
 
 /* returns the value (a pointer to the data element) at the current
    position */ 

--- a/rwhoisd/common/misc.h
+++ b/rwhoisd/common/misc.h
@@ -29,9 +29,9 @@ char *get_word PROTO((char *cp, char *buf));
 
 void paste PROTO((char *line, char *cut_start, char *cut_end, char *rpl));
 
-char *on_off PROTO((int bool));
+char *on_off PROTO((int b));
 
-int true_false PROTO((char *bool));
+int true_false PROTO((char *b));
 
 int get_tuple PROTO((char *tag1, char *tag2, char *data, char *line));
 
@@ -54,7 +54,7 @@ void *xmemdup PROTO((const void *buf, size_t bytes));
 
 char *regncpy PROTO((char *result, regexp *prog, int item, int len));
 
-char *true_false_str PROTO((int bool));
+char *true_false_str PROTO((int b));
 
 void randomize PROTO((void));
 

--- a/rwhoisd/common/punt_ref.c
+++ b/rwhoisd/common/punt_ref.c
@@ -34,7 +34,7 @@ create_punt_ref(ref_list)
 
   *ref_list = xcalloc(1, sizeof(**ref_list));
 
-  if (!dl_list_default(*ref_list, TRUE, destroy_punt_ref_data))
+  if (!dl_list_default(*ref_list, TRUE, (int(*)(void *))destroy_punt_ref_data))
   {
     log(L_LOG_ERR, CONFIG, "Error in creating punt/root referral list");
     return FALSE;

--- a/rwhoisd/common/schema.c
+++ b/rwhoisd/common/schema.c
@@ -225,7 +225,7 @@ append_class( class, aa )
   if (!dl_list_last(class_list))
   {
     class->id = 0;
-    dl_list_default(class_list, FALSE, destroy_class_data);
+    dl_list_default(class_list, FALSE, (int(*)(void *))destroy_class_data);
   }
   else
   {
@@ -456,7 +456,7 @@ add_class(schema, class, aa)
   if (!dl_list_last(class_list))
   {
     class->id = 0;
-    dl_list_default(class_list, FALSE, destroy_class_data);
+    dl_list_default(class_list, FALSE, (int(*)(void *))destroy_class_data);
   }
   else
   {
@@ -542,7 +542,7 @@ add_global_class(class, aa)
     {
       class_ref_list = xcalloc(1, sizeof(*class_ref_list));
 
-      dl_list_default(class_ref_list, TRUE, destroy_class_ref_data);
+      dl_list_default(class_ref_list, TRUE, (int(*)(void *))destroy_class_ref_data);
     }
 
     /* allocate and set the new node */

--- a/rwhoisd/mkdb/anon_record.c
+++ b/rwhoisd/mkdb/anon_record.c
@@ -89,7 +89,7 @@ mkdb_read_anon_record(data_file_no, validate_flag, status, fp)
   rec->offset       = ftell(fp);
   
   av_list = &(rec->anon_av_pair_list);
-  dl_list_default(av_list, FALSE, destroy_anon_av_pair_data);
+  dl_list_default(av_list, FALSE, (int(*)(void *))destroy_anon_av_pair_data);
 
   eof_flag = TRUE;  /* flag is set differently if loop ends for a different
                        reason */

--- a/rwhoisd/mkdb/delete.c
+++ b/rwhoisd/mkdb/delete.c
@@ -43,8 +43,8 @@ mkdb_delete_record_list (record_list)
   {
     record = dl_list_value(record_list);
 
-    dl_list_default(&all_file_list, FALSE, destroy_file_struct_data);
-    dl_list_default(&changed_fi_list, FALSE, destroy_file_struct_data);
+    dl_list_default(&all_file_list, FALSE, (int(*)(void *))destroy_file_struct_data);
+    dl_list_default(&changed_fi_list, FALSE, (int(*)(void *))destroy_file_struct_data);
 
     if (!get_file_list(record->class, record->auth_area, &all_file_list))
     {

--- a/rwhoisd/mkdb/fileinfo.c
+++ b/rwhoisd/mkdb/fileinfo.c
@@ -1024,7 +1024,7 @@ get_file(class_name, auth_area_name, file_list)
   }
 
   /* initialize the list */
-  dl_list_default(file_list, FALSE, destroy_file_struct_data);
+  dl_list_default(file_list, FALSE, (int(*)(void *))destroy_file_struct_data);
 
   auth_area = find_auth_area_by_name(auth_area_name);
   if (auth_area == NULL)
@@ -1161,7 +1161,7 @@ add_single_file(class, auth_area, file_name, type, num_recs)
   file_struct  *list_file;
   dl_list_type file_list;
 
-  dl_list_default(&file_list, FALSE, destroy_file_struct_data);
+  dl_list_default(&file_list, FALSE, (int(*)(void *))destroy_file_struct_data);
 
   file = build_base_file_struct(file_name, type, num_recs);
   if (!file)
@@ -1214,7 +1214,7 @@ modify_file_list(class, auth_area, add_list, delete_list,
     return FALSE;
   }
 
-  dl_list_default(&full_file_list, FALSE, destroy_file_struct_data);
+  dl_list_default(&full_file_list, FALSE, (int(*)(void *))destroy_file_struct_data);
 
   /* first, we establish the write lock; This prevents staleness
      problems. */
@@ -1392,8 +1392,8 @@ records_in_auth_area(auth_area)
   long         count    = 0;
   int          not_done;
 
-  dl_list_default(&master_file_list, FALSE, destroy_file_struct_data);
-  dl_list_default(&data_file_list, FALSE, destroy_file_struct_data);
+  dl_list_default(&master_file_list, FALSE, (int(*)(void *))destroy_file_struct_data);
+  dl_list_default(&data_file_list, FALSE, (int(*)(void *))destroy_file_struct_data);
 
   if (!get_file(NULL, auth_area->name, &master_file_list))
   {

--- a/rwhoisd/mkdb/index.c
+++ b/rwhoisd/mkdb/index.c
@@ -644,9 +644,9 @@ index_files(class, auth_area, index_file_list, data_file_list, validate_flag,
     return TRUE;
   }
 
-  dl_list_default(&delete_list, FALSE, destroy_file_struct_data);
-  dl_list_default(&add_list, FALSE, destroy_file_struct_data);
-  dl_list_default(&unlock_list, FALSE, destroy_file_struct_data);
+  dl_list_default(&delete_list, FALSE, (int(*)(void *))destroy_file_struct_data);
+  dl_list_default(&add_list, FALSE, (int(*)(void *))destroy_file_struct_data);
+  dl_list_default(&unlock_list, FALSE, (int(*)(void *))destroy_file_struct_data);
 
   /* add/update all of our data files to the master file list(s) */
   if (! modify_file_list(class, auth_area, data_file_list, NULL, NULL, NULL,
@@ -798,7 +798,7 @@ index_files_by_name(class_name, auth_area_name, base_dir,
     return FALSE;
   }
 
-  dl_list_default(&data_file_list, FALSE, destroy_file_struct_data);
+  dl_list_default(&data_file_list, FALSE, (int(*)(void *))destroy_file_struct_data);
   if (! build_file_list_by_names(&data_file_list, MKDB_DATA_FILE,
                                  base_dir, num_data_files, file_names))
   {
@@ -809,7 +809,7 @@ index_files_by_name(class_name, auth_area_name, base_dir,
   }
 
 
-  dl_list_default(&index_file_list, FALSE, destroy_index_fp_data);
+  dl_list_default(&index_file_list, FALSE, (int(*)(void *))destroy_index_fp_data);
   if (!build_index_list(class, auth_area, &index_file_list, class->db_dir,
                         NULL))
   {
@@ -865,7 +865,7 @@ index_files_by_suffix(class_name, auth_area_name, suffix, validate_flag)
 
 
   /* create and build the data file list */
-  dl_list_default(&data_file_list, FALSE, destroy_file_struct_data);
+  dl_list_default(&data_file_list, FALSE, (int(*)(void *))destroy_file_struct_data);
   if (!build_file_list_by_suffix(&data_file_list, MKDB_DATA_FILE,
                                  class->db_dir, suffix))
   {
@@ -878,7 +878,7 @@ index_files_by_suffix(class_name, auth_area_name, suffix, validate_flag)
 
 
   /* create and build the index file list */
-  dl_list_default(&index_file_list, FALSE, destroy_index_fp_data);
+  dl_list_default(&index_file_list, FALSE, (int(*)(void *))destroy_index_fp_data);
 
   if (!build_index_list(class, auth_area, &index_file_list, class->db_dir,
                         NULL))

--- a/rwhoisd/mkdb/records.c
+++ b/rwhoisd/mkdb/records.c
@@ -133,7 +133,7 @@ mkdb_translate_anon_record(anon, class, auth_area, validate_flag)
   rec->class        = class;
 
   av_list           = &(rec->av_pair_list);
-  dl_list_default(av_list, FALSE, destroy_av_pair_data);
+  dl_list_default(av_list, FALSE, (int(*)(void *))destroy_av_pair_data);
   
   /* handle auth_area */
   anon_av = find_anon_auth_area_in_rec(anon);
@@ -447,7 +447,7 @@ copy_record(rec)
   bcopy(rec, copy, sizeof(*copy));
 
   /* copy the av_pair list */
-  dl_list_default(&(copy->av_pair_list), FALSE, destroy_av_pair_data);
+  dl_list_default(&(copy->av_pair_list), FALSE, (int(*)(void *))destroy_av_pair_data);
 
   not_done = dl_list_first(&(rec->av_pair_list));
   while (not_done)

--- a/rwhoisd/mkdb/search.c
+++ b/rwhoisd/mkdb/search.c
@@ -349,9 +349,9 @@ search_class(query_tree, auth_area, class, record_list, max_hits)
 
   bzero((char *)index_file, sizeof(index_file));
 
-  dl_list_default(&master_fi_list, FALSE, destroy_file_struct_data);
-  dl_list_default(&index_fi_list, FALSE, destroy_file_struct_data);
-  dl_list_default(&data_fi_list, FALSE, destroy_file_struct_data);
+  dl_list_default(&master_fi_list, FALSE, (int(*)(void *))destroy_file_struct_data);
+  dl_list_default(&index_fi_list, FALSE, (int(*)(void *))destroy_file_struct_data);
+  dl_list_default(&data_fi_list, FALSE, (int(*)(void *))destroy_file_struct_data);
 
   /* Ok, this needs a little bit of explaining because there is an
      implicit filtering function here handled by the indexer. What we

--- a/rwhoisd/regexp/regexp.c
+++ b/rwhoisd/regexp/regexp.c
@@ -223,7 +223,7 @@ char *exp;
         register char *longest;
         register int len;
         int flags;
-        extern void *malloc();
+        extern void *malloc(size_t);
 
         if (exp == NULL)
                 FAIL("NULL argument");

--- a/rwhoisd/regexp/regsub.c
+++ b/rwhoisd/regexp/regsub.c
@@ -42,7 +42,7 @@ char *dest;
 	register char c;
 	register int no;
 	register int len;
-	extern char *strncpy();
+	extern char *strncpy(char *, const char*, size_t);
 
 	if (prog == NULL || source == NULL || dest == NULL) {
 		regerror("NULL parm to regsub");

--- a/rwhoisd/server/guardian.c
+++ b/rwhoisd/server/guardian.c
@@ -219,7 +219,7 @@ lookup_guardian_record(guard_id)
     return NULL;
   }
 
-  dl_list_default(&new_rec_list, FALSE, destroy_record_data);
+  dl_list_default(&new_rec_list, FALSE, (int(*)(void *))destroy_record_data);
   num_recs = search(query, &new_rec_list, 2, &ret_code);
 
   destroy_query(query);

--- a/rwhoisd/server/referral.c
+++ b/rwhoisd/server/referral.c
@@ -371,7 +371,7 @@ get_down_referral(hvalue, htype, aa_name, referral_list)
       break;
     }
 
-    dl_list_default(&record_list, FALSE, destroy_record_data);
+    dl_list_default(&record_list, FALSE, (int(*)(void *))destroy_record_data);
 
     search(query, &record_list, 1, &ret_code);
 
@@ -644,7 +644,7 @@ refer_query(query)
     return(rval);
   }
 
-  dl_list_default(&referral_list, FALSE, destroy_referral_data);
+  dl_list_default(&referral_list, FALSE, (int(*)(void *))destroy_referral_data);
 
   /* Traverse the query tree to get referral for a particular
      query term.  Break the loop on the first hit. */

--- a/rwhoisd/server/register.c
+++ b/rwhoisd/server/register.c
@@ -203,7 +203,7 @@ check_uniq_record(record)
   ret_code_type ret_code;
   
   query = xcalloc(1, sizeof(*query));
-  dl_list_default(&record_list, FALSE, destroy_record_data);
+  dl_list_default(&record_list, FALSE, (int(*)(void *))destroy_record_data);
   
   if (!build_primary_key_query(query, record))
   {
@@ -325,7 +325,7 @@ index_new_record(record)
   /* generate the new filename */
   create_filename(store_fname, DB_FILE_TEMPLATE, class->db_dir);
 
-  dl_list_default(&index_file_list, FALSE, destroy_index_fp_data);
+  dl_list_default(&index_file_list, FALSE, (int(*)(void *))destroy_index_fp_data);
   if (!build_index_list(class, aa, &index_file_list, class->db_dir,
                         "addind"))
   {
@@ -349,7 +349,7 @@ index_new_record(record)
 
   /* index the file */
   file_ptr = build_base_file_struct(store_fname, MKDB_DATA_FILE, 1);
-  dl_list_default(&dl_file_list, FALSE, destroy_file_struct_data);
+  dl_list_default(&dl_file_list, FALSE, (int(*)(void *))destroy_file_struct_data);
   dl_list_append(&dl_file_list, file_ptr);
   
   status = index_files(class, aa, &index_file_list, &dl_file_list,
@@ -757,7 +757,7 @@ process_registration(reg_email, action)
   }
   /* CHECK phase -- check for syntactical and usage problems */
 
-  dl_list_default(&del_record_list, FALSE, destroy_record_data);
+  dl_list_default(&del_record_list, FALSE, (int(*)(void *))destroy_record_data);
   
   switch (action)
   {

--- a/rwhoisd/server/session.c
+++ b/rwhoisd/server/session.c
@@ -99,7 +99,7 @@ run_query(str)
   
   query = xcalloc(1, sizeof(*query));
   
-  dl_list_default(&record_list, FALSE, destroy_record_data);
+  dl_list_default(&record_list, FALSE, (int(*)(void *))destroy_record_data);
   
   if (!str || !*str)
   {

--- a/rwhoisd/server/sresponse.c
+++ b/rwhoisd/server/sresponse.c
@@ -173,7 +173,7 @@ recv_response(fp, delimiter, response)
   char line[MAX_LINE];
   int  not_done        = TRUE;
 
-  dl_list_default(response, FALSE, destroy_response_data);
+  dl_list_default(response, FALSE, (int(*)(void *))destroy_response_data);
 
   /* Read response line by line till delimiter */
   do

--- a/rwhoisd/server/sstate.c
+++ b/rwhoisd/server/sstate.c
@@ -138,7 +138,7 @@ init_slave_state_list(slave_aa_list)
     return;
   }
  
-  dl_list_default(&slave_state_list, FALSE, destroy_slave_state_data);
+  dl_list_default(&slave_state_list, FALSE, (int(*)(void *))destroy_slave_state_data);
  
   not_done = dl_list_first(slave_aa_list);
   while (not_done)

--- a/rwhoisd/server/sxfer.c
+++ b/rwhoisd/server/sxfer.c
@@ -264,7 +264,7 @@ xfer_parse_args(str, aa)
   }
 
   xs = xcalloc(1, sizeof(*xs));
-  dl_list_default(&(xs->xfer_class_list), FALSE, destroy_xfer_class_data);
+  dl_list_default(&(xs->xfer_class_list), FALSE, (int(*)(void *))destroy_xfer_class_data);
 
   for (i = 0; i < argc; i++)
   {
@@ -279,7 +279,7 @@ xfer_parse_args(str, aa)
       if (STR_EQ(attr, "class"))
       {
         cur_xclass = xcalloc(1, sizeof(*cur_xclass));
-        dl_list_default(&(cur_xclass->attr_list), FALSE, null_destroy_data);
+        dl_list_default(&(cur_xclass->attr_list), FALSE, (int(*)(void *))null_destroy_data);
         
         class = find_class_by_name(aa->schema, value);
         if (!class)
@@ -538,11 +538,11 @@ index_data_files_by_suffix(aa, suffix)
     }
     
     /* Get current data and index files list */ 
-    dl_list_default(&full_file_list, FALSE, destroy_file_struct_data);
+    dl_list_default(&full_file_list, FALSE, (int(*)(void *))destroy_file_struct_data);
     get_file_list(class, aa, &full_file_list);
 
     /* Build new data files list */
-    dl_list_default(&data_file_list, FALSE, destroy_file_struct_data);
+    dl_list_default(&data_file_list, FALSE, (int(*)(void *))destroy_file_struct_data);
     if (!build_file_list_by_suffix(&data_file_list, MKDB_DATA_FILE,
                                    class->db_dir, suffix))
     {
@@ -550,7 +550,7 @@ index_data_files_by_suffix(aa, suffix)
       break;
     }
 
-    dl_list_default(&index_file_list, FALSE, destroy_index_fp_data);
+    dl_list_default(&index_file_list, FALSE, (int(*)(void *))destroy_index_fp_data);
     if (!build_index_list(class, aa, &index_file_list, class->db_dir, NULL))
     {
       rval = FALSE;

--- a/rwhoisd/server/xfer.c
+++ b/rwhoisd/server/xfer.c
@@ -149,7 +149,7 @@ xfer_parse_args(str)
   }
 
   xs = xcalloc(1, sizeof(*xs));
-  dl_list_default(&(xs->xfer_class_list), FALSE, destroy_xfer_class_data);
+  dl_list_default(&(xs->xfer_class_list), FALSE, (int(*)(void *))destroy_xfer_class_data);
 
   if (STR_EQ(world, argv[0]))
   {
@@ -219,7 +219,7 @@ xfer_parse_args(str)
       if (STR_EQ(attr, "class"))
       {
         cur_xclass = xcalloc(1, sizeof(*cur_xclass));
-        dl_list_default(&(cur_xclass->attr_list), FALSE, null_destroy_data);
+        dl_list_default(&(cur_xclass->attr_list), FALSE, (int(*)(void *))null_destroy_data);
         
         class = find_class_by_name(aa->schema, value);
         if (!class)
@@ -418,8 +418,8 @@ xfer_class(aa, class, curr_class, serial_no)
     return FALSE;
   }
 
-  dl_list_default(&master_file_list, FALSE, destroy_file_struct_data);
-  dl_list_default(&file_list, FALSE, destroy_file_struct_data);
+  dl_list_default(&master_file_list, FALSE, (int(*)(void *))destroy_file_struct_data);
+  dl_list_default(&file_list, FALSE, (int(*)(void *))destroy_file_struct_data);
   
   /* pull all of the data files for the current class */
   if (!get_file_list(class, aa, &master_file_list))

--- a/rwhoisd/tools/rwhois_deleter/rwhois_deleter.c
+++ b/rwhoisd/tools/rwhois_deleter/rwhois_deleter.c
@@ -110,7 +110,7 @@ query_for_records(query_string, limit, total)
   *total = 0;
 
   record_list = (dl_list_type *) xcalloc(1, sizeof(*record_list));
-  dl_list_default(record_list, TRUE, destroy_record_data);
+  dl_list_default(record_list, TRUE, (int(*)(void *))destroy_record_data);
   
   if (!parse_query(query_string, &query))
   {

--- a/rwhoisd/tools/rwhois_indexer/rwhois_indexer.c
+++ b/rwhoisd/tools/rwhois_indexer/rwhois_indexer.c
@@ -71,8 +71,8 @@ delete_index_files(class, auth_area)
   file_struct  *index_file;
   int          not_done;
   
-  dl_list_default(&master_file_list, FALSE, destroy_file_struct_data);
-  dl_list_default(&index_file_list, FALSE, destroy_file_struct_data);
+  dl_list_default(&master_file_list, FALSE, (int(*)(void *))destroy_file_struct_data);
+  dl_list_default(&index_file_list, FALSE, (int(*)(void *))destroy_file_struct_data);
 
   /* get the index file_structs for the particular class */
   if (! get_file_list(class, auth_area, &master_file_list))

--- a/rwhoisd/tools/rwhois_repack/rwhois_repack.c
+++ b/rwhoisd/tools/rwhois_repack/rwhois_repack.c
@@ -365,10 +365,10 @@ repack_index_files(class_struct *class,
   if (dl_list_empty(index_file_list)) return TRUE;
 
 
-  dl_list_default(&sub_index_file_list, FALSE, destroy_file_struct_data);
-  dl_list_default(&base_index_file_list, FALSE, destroy_index_fp_data);
-  dl_list_default(&new_index_file_list, FALSE, destroy_index_fp_data);
-  dl_list_default(&add_file_list, FALSE, destroy_file_struct_data);
+  dl_list_default(&sub_index_file_list, FALSE, (int(*)(void *))destroy_file_struct_data);
+  dl_list_default(&base_index_file_list, FALSE, (int(*)(void *))destroy_index_fp_data);
+  dl_list_default(&new_index_file_list, FALSE, (int(*)(void *))destroy_index_fp_data);
+  dl_list_default(&add_file_list, FALSE, (int(*)(void *))destroy_file_struct_data);
 
   /* generate the various possible index files we could create */
   if (! build_index_list(class, auth_area, &base_index_file_list,
@@ -534,8 +534,8 @@ run_repack_class_aa(class_struct          *class,
   }
 
   /* initialize the list */
-  dl_list_default(&index_file_list, FALSE, destroy_file_struct_data);
-  dl_list_default(&all_file_list, FALSE, destroy_file_struct_data);
+  dl_list_default(&index_file_list, FALSE, (int(*)(void *))destroy_file_struct_data);
+  dl_list_default(&all_file_list, FALSE, (int(*)(void *))destroy_file_struct_data);
 
   /* get the file list from master index file (local.db) */
   if (! get_file_list(class, auth_area, &all_file_list) )


### PR DESCRIPTION
A build failed with GCC 15 because that compiler moved to ISO C23 langauge version:

    misc.h:32:25: error: ‘bool’ cannot be used here
       32 | char *on_off PROTO((int bool));
	  |                         ^~~~

The cause is that ISO C23 added "bool" type. This patchs changes the argument name to match the function definitions.

    attributes.c: In function ‘add_attribute’:
    attributes.c:552:39: error: passing argument 3 of ‘dl_list_default’ from incompatible pointer type [-Wincompatible-pointer-types]
      552 |     dl_list_default(attr_list, FALSE, destroy_attr_data);
	  |                                       ^~~~~~~~~~~~~~~~~
	  |                                       |
	  |                                       int (*)(attribute_struct *) {aka int (*)(struct _attribute_struct *)}
    In file included from attributes.h:15,
		     from attributes.c:10:
    dl_list.h:44:34: note: expected ‘int (*)(void)’ but argument is of type ‘int (*)(attribute_struct *)’ {aka ‘int (*)(struct _attribute_struct *)’}
       44 |                            int (*destroy_data)()));
	  |                            ~~~~~~^~~~~~~~~~~~~~~

ISO C23 changed meaning of "int foo()" to "int foo(void)". This patch addapts to it.